### PR TITLE
Add openapi Django command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 Version Next
 
+ * Add new Django command ``openapi``. Generates ``openapi.yaml``
  * ...
 
 Version 0.37
@@ -10,7 +11,7 @@ Version 0.37
 Version 0.36
 
  * Codebase is blackened
- * `lint --create` will also generate a valid but incomplete `openapi.yaml`:
+ * ``lint --create`` will also generate a valid but incomplete ``openapi.yaml``:
 
    * includes paths, methods, path parameters, request schema, response schema
    * operations include operationId, description and summary (if found)

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -143,6 +143,8 @@ def convert_endpoint_to_operation(endpoint: AcceptableAPI, path_parameters: dict
 
 def extract_path_parameters(url: str) -> Tuple[str, dict]:
     # convert URL from metadata-style to openapi-style
+    if url is None or url == "":
+        url = "/"
     url = url.replace("<", "{").replace(">", "}")
 
     # get individual instances of `{...}`

--- a/acceptable/tests/test_openapi.py
+++ b/acceptable/tests/test_openapi.py
@@ -107,7 +107,7 @@ class TidyStringTests(testtools.TestCase):
 class ParameterExtractionTests(testtools.TestCase):
     def test_blank(self):
         url, parameters = openapi.extract_path_parameters("")
-        assert url == ""
+        assert url == "/"
         assert parameters == {}
 
     def test_no_parameters(self):


### PR DESCRIPTION
* Adds a new command `openapi` to Django.
* Empty path is now recorded as `/` (root)
