### PR TITLE
Update format when a single endpoint supports multiple methods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Version Next
 
  * Add new Django command ``openapi``. Generates ``openapi.yaml``
+ * Update format when a single endpoint supports multiple methods.
+ * 📢 Please note! operationId now includes both the endpoint name and the method. For example, ``validation-get`` instead of ``validation``. This allows multiple methods on a single endpoint, such as ``validation-post`` and ``validation-get``.
  * ...
 
 Version 0.37

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -119,7 +119,9 @@ def tidy_string(untidy: Any):
     return tidy.strip()
 
 
-def convert_endpoint_to_operation(endpoint: AcceptableAPI, method: str, path_parameters: dict):
+def convert_endpoint_to_operation(
+    endpoint: AcceptableAPI, method: str, path_parameters: dict
+):
     if endpoint.request_schema is None:
         _request_schema = "#/components/schemas/Default"
     else:
@@ -204,7 +206,9 @@ def dump(metadata: APIMetadata, stream=None):
                 for method in endpoint.methods:
                     method = str.lower(method)
                     tidy_url, path_parameters = extract_path_parameters(endpoint.url)
-                    operation = convert_endpoint_to_operation(endpoint, method, path_parameters)
+                    operation = convert_endpoint_to_operation(
+                        endpoint, method, path_parameters
+                    )
                     tags.update(set(operation.tags))
                     oas.paths[tidy_url][method] = operation
 

--- a/acceptable/tests/test_openapi.py
+++ b/acceptable/tests/test_openapi.py
@@ -149,13 +149,13 @@ class EndpointToOperationTests(testtools.TestCase):
     def test_blank():
         endpoint = AcceptableAPI(
             introduced_at=1,
-            name="test name",  # maps to operation.operation_id
+            name="test-name",  # maps to operation.operation_id
             service=AcceptableService(name="test service"),
             url="https://test.example",
         )
-        operation = openapi.convert_endpoint_to_operation(endpoint, {})
+        operation = openapi.convert_endpoint_to_operation(endpoint, "get", {})
         assert "None" == operation.description
-        assert "test name" == operation.operation_id
+        assert "test-name-get" == operation.operation_id
         assert operation.summary is None
         assert 1 == len(operation.tags)
         assert "none" == operation.tags[0]
@@ -164,7 +164,7 @@ class EndpointToOperationTests(testtools.TestCase):
     def test_populated():
         endpoint = AcceptableAPI(
             introduced_at=1,
-            name="test name",  # maps to operation.operation_id
+            name="test-name",  # maps to operation.operation_id
             service=AcceptableService(
                 name="test service", group="test group"  # maps to operation.tags
             ),
@@ -172,9 +172,9 @@ class EndpointToOperationTests(testtools.TestCase):
             url="https://test.example",
         )
         endpoint.docs = "test docs"  # maps to operation.description
-        operation = openapi.convert_endpoint_to_operation(endpoint, {})
+        operation = openapi.convert_endpoint_to_operation(endpoint, "get", {})
         assert "test docs" == operation.description
-        assert "test name" == operation.operation_id
+        assert "test-name-get" == operation.operation_id
         assert "test title" == operation.summary
         assert 1 == len(operation.tags)
         assert "test group" == operation.tags[0]

--- a/examples/oas_testcase_expected.yaml
+++ b/examples/oas_testcase_expected.yaml
@@ -18,7 +18,7 @@ paths:
   /foo/{p}/{q}:
     get:
       description: Documentation goes here.
-      operationId: foo
+      operationId: foo-get
       parameters:
       - in: path
         name: p

--- a/examples/oas_testcase_openapi.yaml
+++ b/examples/oas_testcase_openapi.yaml
@@ -18,7 +18,7 @@ paths:
   /foo/{p}/{q}:
     get:
       description: Documentation goes here.
-      operationId: foo
+      operationId: foo-get
       parameters:
       - in: path
         name: p


### PR DESCRIPTION
The existing format was not working for Django exports. This should work for existing microservices and Django-powered APIs.

The change in operationId value is low/no impact.