### PR TITLE
Pin tox at 3.x to fix failing tests

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -27,6 +27,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions
+          pip install "tox<4" tox-gh-actions
       - name: Run tox
         run: tox

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ env/.done: requirements-dev.txt setup.py
 	touch $@
 
 env/bin/tox: env/.done
-	env/bin/pip install tox
+	env/bin/pip install "tox<4"
 
 .PHONY: lint
 lint: env/.done


### PR DESCRIPTION
Yesterday after a merge, previously passing tests started failing. The tests still pass under `make test` but fail under `make tox`.

Investigation revealed that the tox environments were missing dependencies, despite them being specified in tox.ini. Reverting to tox 3.x fixes this issue. Obviously we want to move back to tox 4.x as soon as possible, but this solves the problem in the meantime.