### PR TITLE
OpenAPI cleanup

### DIFF
--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -37,15 +37,13 @@ class OasOperation:
     def _to_dict(self):
         result = {
             "tags": self.tags,
-            "summary": self.summary,
             "description": tidy_string(self.description) or "None.",
             "operationId": self.operation_id,
             "parameters": list(self._parameters_to_openapi()),
         }
 
-        # drop empty summary
-        if not self.summary:
-            result.pop("summary")
+        if self.summary:
+            result["summary"] = self.summary
 
         if self.request_schema:
             result["requestBody"] = {

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -52,7 +52,9 @@ class OasOperation:
 
         result["responses"] = {"200": {"description": self.summary or "OK"}}
         if self.response_schema:
-            result["responses"]["200"]["content"] = {"application/json": {"schema": self.response_schema}}
+            result["responses"]["200"]["content"] = {
+                "application/json": {"schema": self.response_schema}
+            }
 
         return result
 

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -43,14 +43,14 @@ class OasOperation:
             "parameters": list(self._parameters_to_openapi()),
             "requestBody": {
                 "content": {
-                    "application/json": {"schema": {"$ref": self.request_schema}}
+                    "application/json": {"schema": self.request_schema}
                 }
             },
             "responses": {
                 "200": {
                     "description": self.summary or "OK",
                     "content": {
-                        "application/json": {"schema": {"$ref": self.response_schema}}
+                        "application/json": {"schema": self.response_schema}
                     },
                 }
             },

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -117,7 +117,7 @@ def convert_endpoint_to_operation(
         _response_schema = json.loads(json.dumps(endpoint.response_schema))
 
     return OasOperation(
-        tags=[endpoint.service.group] if endpoint.service.group else ["none"],
+        tags=[endpoint.service.group] if endpoint.service.group else [],
         summary=endpoint.title,
         description=tidy_string(endpoint.docs),
         operation_id=f"{endpoint.name}-{method}",

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -82,14 +82,6 @@ class OasRoot31:
             "servers": _to_dict(self.servers),
             "tags": _to_dict(self.tags),
             "paths": _to_dict(self.paths),
-            "components": {
-                "schemas": {
-                    "Default": {
-                        "type": "object",
-                        "properties": {"code": {"type": "integer", "format": "int32"}},
-                    }
-                }
-            },
         }
 
 

--- a/acceptable/tests/test_openapi.py
+++ b/acceptable/tests/test_openapi.py
@@ -157,8 +157,7 @@ class EndpointToOperationTests(testtools.TestCase):
         assert "None" == operation.description
         assert "test-name-get" == operation.operation_id
         assert operation.summary is None
-        assert 1 == len(operation.tags)
-        assert "none" == operation.tags[0]
+        assert 0 == len(operation.tags)
 
     @staticmethod
     def test_populated():

--- a/examples/oas_empty_expected.yaml
+++ b/examples/oas_empty_expected.yaml
@@ -1,11 +1,3 @@
-components:
-  schemas:
-    Default:
-      properties:
-        code:
-          format: int32
-          type: integer
-      type: object
 info:
   contact:
     email: example@example.example

--- a/examples/oas_testcase_expected.yaml
+++ b/examples/oas_testcase_expected.yaml
@@ -34,39 +34,37 @@ paths:
         content:
           application/json:
             schema:
-              $ref:
-                properties:
-                  baz:
-                    description: Bar the door.
-                    introduced_at: 4
-                    properties:
-                      bar:
-                        description: asdf
-                        introduced_at: 5
-                        type: string
-                    type: object
-                  foo:
-                    description: This is a foo.
-                    type: string
-                required:
-                - foo
-                - baz
-                type: object
+              properties:
+                baz:
+                  description: Bar the door.
+                  introduced_at: 4
+                  properties:
+                    bar:
+                      description: asdf
+                      introduced_at: 5
+                      type: string
+                  type: object
+                foo:
+                  description: This is a foo.
+                  type: string
+              required:
+              - foo
+              - baz
+              type: object
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref:
-                  properties:
-                    bar:
-                      description: bar bar
-                      introduced_at: 5
-                      type: string
-                    foo_result:
-                      description: Result of a foo.
-                      type: string
-                  type: object
+                properties:
+                  bar:
+                    description: bar bar
+                    introduced_at: 5
+                    type: string
+                  foo_result:
+                    description: Result of a foo.
+                    type: string
+                type: object
           description: OK
       tags:
       - none

--- a/examples/oas_testcase_expected.yaml
+++ b/examples/oas_testcase_expected.yaml
@@ -1,11 +1,3 @@
-components:
-  schemas:
-    Default:
-      properties:
-        code:
-          format: int32
-          type: integer
-      type: object
 info:
   contact:
     email: example@example.example

--- a/examples/oas_testcase_expected.yaml
+++ b/examples/oas_testcase_expected.yaml
@@ -58,9 +58,7 @@ paths:
                     type: string
                 type: object
           description: OK
-      tags:
-      - none
+      tags: []
 servers:
 - url: http://localhost
-tags:
-- name: none
+tags: []

--- a/examples/oas_testcase_openapi.yaml
+++ b/examples/oas_testcase_openapi.yaml
@@ -34,39 +34,37 @@ paths:
         content:
           application/json:
             schema:
-              $ref:
-                properties:
-                  baz:
-                    description: Bar the door.
-                    introduced_at: 4
-                    properties:
-                      bar:
-                        description: asdf
-                        introduced_at: 5
-                        type: string
-                    type: object
-                  foo:
-                    description: This is a foo.
-                    type: string
-                required:
-                - foo
-                - baz
-                type: object
+              properties:
+                baz:
+                  description: Bar the door.
+                  introduced_at: 4
+                  properties:
+                    bar:
+                      description: asdf
+                      introduced_at: 5
+                      type: string
+                  type: object
+                foo:
+                  description: This is a foo.
+                  type: string
+              required:
+              - foo
+              - baz
+              type: object
       responses:
         '200':
           content:
             application/json:
               schema:
-                $ref:
-                  properties:
-                    bar:
-                      description: bar bar
-                      introduced_at: 5
-                      type: string
-                    foo_result:
-                      description: Result of a foo.
-                      type: string
-                  type: object
+                properties:
+                  bar:
+                    description: bar bar
+                    introduced_at: 5
+                    type: string
+                  foo_result:
+                    description: Result of a foo.
+                    type: string
+                type: object
           description: OK
       tags:
       - none

--- a/examples/oas_testcase_openapi.yaml
+++ b/examples/oas_testcase_openapi.yaml
@@ -1,11 +1,3 @@
-components:
-  schemas:
-    Default:
-      properties:
-        code:
-          format: int32
-          type: integer
-      type: object
 info:
   contact:
     email: example@example.example

--- a/examples/oas_testcase_openapi.yaml
+++ b/examples/oas_testcase_openapi.yaml
@@ -58,9 +58,7 @@ paths:
                     type: string
                 type: object
           description: OK
-      tags:
-      - none
+      tags: []
 servers:
 - url: http://localhost
-tags:
-- name: none
+tags: []


### PR DESCRIPTION
- Drop rogue `"$ref"` from generated OpenAPI specs.
- Skip unspecified request & response schemas from generated OpenAPI spec.
- Skip unspecified endpoint summary from generated OpenAPI spec.
- Do not include a default schema in generated OpenAPI specs.
- Do not add the `"none"` tag to untagged endpoints in generated OpenAPI specs.

Check commits for details.

Most of these changes have a corresponding hack/translation/workaround in `snapstore-schemas`. Plan is to drop these hacks once all projects have updated their openapi specs.