### PR TITLE
Update to Python 3.12

### DIFF
--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -6,7 +6,12 @@ import textwrap
 from collections import OrderedDict
 
 from acceptable import _validation
-from acceptable.util import clean_docstring, get_callsite_location, sort_schema
+from acceptable.util import (
+    clean_docstring,
+    get_callsite_location,
+    get_function_location,
+    sort_schema,
+)
 
 
 class InvalidAPI(Exception):
@@ -395,7 +400,7 @@ class AcceptableAPI:
         if self.request_schema:
             wrapped = _validation.wrap_request(wrapped, self.request_schema)
 
-        location = get_callsite_location()
+        location = get_function_location(fn)
         # this will be the lineno of the last decorator, so we want one
         # below it for the actual function
         location["lineno"] += 1
@@ -415,7 +420,7 @@ class AcceptableAPI:
     # legacy view decorator
     def view(self, introduced_at):
         def decorator(fn):
-            location = get_callsite_location()
+            location = get_function_location(fn)
             # this will be the lineno of the last decorator, so we want one
             # below it for the actual function
             location["lineno"] += 1

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -79,7 +79,7 @@ class OasInfo:
 @dataclass
 class OasRoot31:
     openapi: str = "3.1.0"
-    info: OasInfo = OasInfo()
+    info: OasInfo = field(default_factory=OasInfo)
     tags: list = field(default_factory=lambda: [])
     servers: list = field(default_factory=lambda: [{"url": "http://localhost"}])
     paths: dict = field(default_factory=lambda: defaultdict(dict))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py310
+envlist = py38, py310, py312
 skip_missing_interpreters = True
 skipsdist = True
 
@@ -7,6 +7,7 @@ skipsdist = True
 python =
     3.8: py38
     3.10: py310
+    3.12: py312
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Python 3.12 introduces a few changes, the most notable being removing a deprecated method of defining module loaders and returning a different value for `.f_fileno` for decorated functions. This PR aims to add support for Python 3.12 while also keeping support for Python 3.8 and 3.10.