### PR TITLE
Add support for OpenAPI "servers", fix query params

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,11 +6,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: psf/black@stable
         with:
           options: "--check --verbose --skip-magic-trailing-comma"
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
       - uses: py-actions/flake8@v2
         with:
           max-line-length: "88"

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -19,9 +19,9 @@ jobs:
         python: [3.8, "3.10", "3.12"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Version Next
 
+Version 0.43
+
+  * Add support for OpenAPI "servers"
+  * Fix rendering of OpenAPI query parameters
   * Drop max required black version
 
 Version 0.42

--- a/acceptable/_service.py
+++ b/acceptable/_service.py
@@ -26,11 +26,12 @@ class APIMetadata:
     and verify uniqueness.
     """
 
-    def __init__(self):
+    def __init__(self, servers=None):
         self.services = OrderedDict()
         self.api_names = set()
         self.urls = set()
         self._current_version = None
+        self.servers = servers
 
     def register_service(self, service, group, docs=None, title=None):
         if service not in self.services:

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -160,7 +160,7 @@ def extract_path_parameters(url: str) -> Tuple[str, dict]:
 
         # if no type is defined, use str
         if c == 0:
-            parameters[p] = "str"
+            parameters[p] = "string"
 
         # if type is defined, use that
         elif c == 1:

--- a/acceptable/openapi.py
+++ b/acceptable/openapi.py
@@ -208,6 +208,9 @@ def dump(metadata: APIMetadata, stream=None):
     for tag in sorted(tags):
         oas.tags.append({"name": tag})
 
+    if metadata.servers:
+        oas.servers = metadata.servers
+
     return yaml.safe_dump(
         _to_dict(oas), stream, default_flow_style=False, encoding=None
     )

--- a/acceptable/tests/test_main.py
+++ b/acceptable/tests/test_main.py
@@ -530,6 +530,7 @@ class RenderMarkdownTests(testtools.TestCase):
             "documentation-builder",
             "--base-directory={}".format(markdown_dir.path),
             "--output-path={}".format(html_dir.path),
+            "--quiet",
         ]
         try:
             subprocess.check_output(build)

--- a/acceptable/tests/test_openapi.py
+++ b/acceptable/tests/test_openapi.py
@@ -86,7 +86,7 @@ class ParameterExtractionTests(testtools.TestCase):
             "https://www.example.com/<test>"
         )
         assert url == "https://www.example.com/{test}"
-        assert parameters == {"test": "str"}
+        assert parameters == {"test": "string"}
 
     def test_typed_parameter(self):
         url, parameters = openapi.extract_path_parameters(

--- a/acceptable/tests/test_openapi.py
+++ b/acceptable/tests/test_openapi.py
@@ -151,7 +151,7 @@ class OpenApiTests(testtools.TestCase):
         result = openapi.dump(metadata).splitlines(keepends=True)
         with open("examples/oas_empty_expected.yaml", "r") as _expected:
             expected = _expected.readlines()
-        self.assertListEqual(expected, result)
+        assert result == expected
 
     def test_single_endpoint_with_multiple_methods(self):
         metadata = APIMetadata()
@@ -164,3 +164,16 @@ class OpenApiTests(testtools.TestCase):
 
         assert list(spec["paths"].keys()) == ["/foo"]
         assert list(spec["paths"]["/foo"].keys()) == ["get", "post"]
+
+    def test_metadata_servers(self):
+        sample_servers = [{"url": "http://test", "description": "Testing"}]
+        metadata = APIMetadata(servers=sample_servers)
+
+        result = openapi.dump(metadata)
+        spec = yaml.safe_load(result)
+
+        with open("examples/oas_empty_expected.yaml", "r") as _expected:
+            expected = yaml.safe_load(_expected.read())
+            expected["servers"] = sample_servers
+
+        assert spec == expected

--- a/examples/django_app/django_app/urls.py
+++ b/examples/django_app/django_app/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import re_path
 
-urlpatterns = [url(r"admin/", admin.site.urls)]
+urlpatterns = [re_path(r"admin/", admin.site.urls)]

--- a/examples/django_app/django_app/views.py
+++ b/examples/django_app/django_app/views.py
@@ -1,6 +1,6 @@
 from django import forms
-from django.conf.urls import include, url
-from django.utils.translation import ugettext_lazy as _
+from django.urls import include, re_path
+from django.utils.translation import gettext_lazy as _
 
 from acceptable import AcceptableService
 
@@ -44,9 +44,9 @@ class TestHandler(object):
 
 
 urlpatterns = [
-    url("^test$", TestHandler(), name="test"),
-    url("^test2/(.*)$", TestHandler(), name="test2"),
-    url("^login$", TestHandler(), name="login"),
-    url("^prefix1/", include(("django_app.urls", "admin"))),
-    url("^prefix2/", include(("django_app.urls", "admin"), namespace="other")),
+    re_path("^test$", TestHandler(), name="test"),
+    re_path("^test2/(.*)$", TestHandler(), name="test2"),
+    re_path("^login$", TestHandler(), name="login"),
+    re_path("^prefix1/", include(("django_app.urls", "admin"))),
+    re_path("^prefix2/", include(("django_app.urls", "admin"), namespace="other")),
 ]

--- a/examples/oas_testcase_expected.yaml
+++ b/examples/oas_testcase_expected.yaml
@@ -21,7 +21,7 @@ paths:
         name: q
         required: true
         schema:
-          type: str
+          type: string
       - in: query
         name: param1
         required: true

--- a/examples/oas_testcase_openapi.yaml
+++ b/examples/oas_testcase_openapi.yaml
@@ -21,7 +21,7 @@ paths:
         name: q
         required: true
         schema:
-          type: str
+          type: string
       - in: query
         name: param1
         required: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ profile = "black"
 skip = ["env", ".tox"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=acceptable --capture=no"
+addopts = "--cov=acceptable"
 
 [tool.coverage.report]
 omit = ["acceptable/tests/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ profile = "black"
 skip = ["env", ".tox"]
 
 [tool.pytest.ini_options]
-addopts = "--cov=acceptable"
+addopts = "--cov=acceptable --capture=no"
 
 [tool.coverage.report]
 omit = ["acceptable/tests/*"]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import find_packages, setup
 
-VERSION = "0.42"
+VERSION = "0.43"
 
 setup(
     name="acceptable",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,13 @@ setup(
     long_description="".join(open("README.rst").readlines()[2:]),
     long_description_content_type="text/x-rst",
     install_requires=["jsonschema", "pyyaml", "Jinja2"],
-    extras_require=dict(flask=["Flask"], django=["django>=2.1,<3"]),
+    extras_require={
+        "flask": ["Flask"],
+        "django": [
+            'django>=2.1,<5;python_version<"3.12"',
+            'django>=4.2.8,<5;python_version>="3.12"',
+        ],
+    },
     test_suite="acceptable.tests",
     include_package_data=True,
     entry_points={"console_scripts": ["acceptable = acceptable.__main__:main"]},

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ extras =
 commands =
     pytest {posargs}
 passenv =
+    HOME
     TRAVIS
     TRAVIS_BRANCH
     TRAVIS_JOB_ID


### PR DESCRIPTION
OpenAPI `servers` can now be customized, but still defaults to `url: http://localhost` if unset.

Also, use `type: string` rather than `type: str` for query parameters. This prevented Swagger UI from building sample requests correctly.